### PR TITLE
refactor(sf-server): move to sf-peerID instead of string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,6 +1065,7 @@ dependencies = [
  "serial_test",
  "sf-logging",
  "sf-metrics",
+ "sf-peer-id",
  "sf-protocol",
  "thiserror",
  "tokio",

--- a/sf-peer-id/src/peer_id.rs
+++ b/sf-peer-id/src/peer_id.rs
@@ -13,7 +13,7 @@ use std::{
 pub type PeerID = FixedSizePeerID<32>;
 
 /// A PeerID instance that allow you to identifies peer within the network
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialOrd, Ord)]
 pub struct FixedSizePeerID<const S: usize> {
     /// The actual size of the PeerID
     size: u8,
@@ -27,8 +27,8 @@ impl<const S: usize> FixedSizePeerID<S> {
     /// # Examples
     ///
     /// ```rust
-    /// use sf-peer::PeerID;
-    /// let id = PeerID::<16>::new([0; 16]);
+    /// use sf_peer_id::FixedSizePeerID;
+    /// let id = FixedSizePeerID::<1>::from_bytes(&[1, 16]).unwrap();
     /// ```
     pub fn from_bytes(mut data: &[u8]) -> Result<Self, Error>
     where
@@ -78,7 +78,44 @@ impl<const S: usize> FixedSizePeerID<S> {
             bytes: [0; S],
         }
     }
+
+    #[cfg(feature = "std")]
+    /// Create a random PeerID
+    pub fn random() -> Result<Self, Error> {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let mut s = String::with_capacity(64);
+        let mut seed = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        for _ in 0..64 {
+            let nibble = (seed & 0xF) as u8;
+            let hex_char = match nibble {
+                0..=9 => (b'0' + nibble) as char,
+                10..=15 => (b'a' + (nibble - 10)) as char,
+                _ => unreachable!(),
+            };
+            s.push(hex_char);
+
+            seed = seed.rotate_left(5) ^ (seed.wrapping_mul(31));
+        }
+
+        Self::from_str(&s)
+    }
 }
+
+impl<const S: usize> PartialEq for FixedSizePeerID<S> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.size != other.size {
+            return false;
+        }
+        self.bytes[..self.size as usize] == other.bytes[..self.size as usize]
+    }
+}
+
+impl<const S: usize> Eq for FixedSizePeerID<S> {}
 
 fn write_peer_id<W>(mut w: W, size: u8, bytes: &[u8]) -> Result<usize, Error>
 where
@@ -150,13 +187,14 @@ impl<const S: usize> FromStr for FixedSizePeerID<S> {
     /// # Examples
     ///
     /// ```rust
-    /// use sf-peer::PeerID;
-    /// let id = PeerID::<16>::from_str("deadbeefdeadbeefdeadbeefdeadbeef").unwrap();
+    /// use sf_peer_id::FixedSizePeerID;
+    /// use std::str::FromStr;
+    /// let id = FixedSizePeerID::<16>::from_str("deadbeefdeadbeefdeadbeefdeadbeef").unwrap();
     /// ```
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let expected_len = 2 * S;
         let current_len = s.len();
-        if current_len != expected_len {
+        if current_len > expected_len {
             return Err(Error::InvalidLength {
                 expected: expected_len,
                 actual: current_len,
@@ -182,7 +220,8 @@ impl<const S: usize> FromStr for FixedSizePeerID<S> {
 #[cfg(feature = "std")]
 impl<const S: usize> Hash for FixedSizePeerID<S> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.bytes.hash(state);
+        self.size.hash(state);
+        self.bytes[..self.size as usize].hash(state);
     }
 }
 
@@ -191,7 +230,7 @@ impl<const S: usize> fmt::Debug for FixedSizePeerID<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "PeerID<{S}>")?;
         f.write_str("(")?;
-        for byte in self.bytes {
+        for byte in &self.bytes[..self.size as usize] {
             write!(f, "{byte:02x}")?;
         }
         f.write_str(")")?;
@@ -202,7 +241,7 @@ impl<const S: usize> fmt::Debug for FixedSizePeerID<S> {
 #[cfg(feature = "std")]
 impl<const S: usize> fmt::Display for FixedSizePeerID<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for byte in &self.bytes {
+        for byte in &self.bytes[..self.size as usize] {
             write!(f, "{byte:02x}")?;
         }
         Ok(())
@@ -273,11 +312,12 @@ mod tests {
 
     #[test]
     fn test_peer_id_from_str_invalid_length() {
-        let result = FixedSizePeerID::<16>::from_str("deadbeefdeadbeef");
+        let result =
+            FixedSizePeerID::<16>::from_str("deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
         assert!(result.is_err());
         if let Err(Error::InvalidLength { expected, actual }) = result {
             assert_eq!(expected, 32);
-            assert_eq!(actual, 16);
+            assert_eq!(actual, 48);
         } else {
             panic!("Expected InvalidLength error");
         }

--- a/sf-peer-id/src/peer_id.rs
+++ b/sf-peer-id/src/peer_id.rs
@@ -74,7 +74,7 @@ impl<const S: usize> FixedSizePeerID<S> {
     // Return a zeroed PeerID
     pub const fn zeroed() -> Self {
         Self {
-            size: S as u8,
+            size: 0,
             bytes: [0; S],
         }
     }
@@ -368,7 +368,9 @@ mod tests {
     #[test]
     fn test_peer_id_size() {
         let id = FixedSizePeerID::<16>::zeroed();
-        assert_eq!(id.size(), 16);
+        assert_eq!(id.size(), 0);
+        let id_2 = FixedSizePeerID::<16>::from_bytes(&[1, 1]).unwrap();
+        assert_ne!(id, id_2);
     }
 
     #[test]

--- a/sf-protocol/Cargo.toml
+++ b/sf-protocol/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+sf-peer-id = { path = "../sf-peer-id" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 

--- a/sf-protocol/src/lib.rs
+++ b/sf-protocol/src/lib.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
+use sf_peer_id::PeerID;
 use std::sync::Arc;
 
 /// Represents an event from peers to the WebSocket server
@@ -12,9 +13,9 @@ pub enum PeerRequest {
     /// Forward/signal event to be sent to another peer
     Forward {
         /// The ID of the peer that sent the forward
-        from_peer_id: Arc<String>,
+        from_peer_id: PeerID,
         /// The ID of the peer to forward the data to
-        to_peer_id: Option<String>,
+        to_peer_id: Option<PeerID>,
         /// The data to be forwarded (owned JSON string slice)
         data: Arc<RawValue>,
     },
@@ -47,11 +48,13 @@ impl PartialEq for PeerRequest {
 #[serde(rename_all = "snake_case")]
 pub enum PeerEvent {
     /// A new peer has connected
-    NewPeer { peer_id: String },
+    NewPeer { peer_id: PeerID },
 }
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
 
     #[test]
@@ -68,8 +71,8 @@ mod tests {
     fn test_peer_request_forward_serialization() {
         let data = serde_json::value::to_raw_value(r#"{"message":"hello"}"#).unwrap();
         let forward = PeerRequest::Forward {
-            from_peer_id: Arc::new("peer1".to_string()),
-            to_peer_id: Some("peer2".to_string()),
+            from_peer_id: PeerID::from_str("peer1").unwrap(),
+            to_peer_id: Some(PeerID::from_str("peer2").unwrap()),
             data: Arc::from(data),
         };
 
@@ -86,14 +89,14 @@ mod tests {
         let data2 = serde_json::value::to_raw_value(r#"{"message":"hello"}"#).unwrap();
 
         let forward1 = PeerRequest::Forward {
-            from_peer_id: Arc::new("peer1".to_string()),
-            to_peer_id: Some("peer2".to_string()),
+            from_peer_id: PeerID::from_str("peer1").unwrap(),
+            to_peer_id: Some(PeerID::from_str("peer2").unwrap()),
             data: Arc::from(data1),
         };
 
         let forward2 = PeerRequest::Forward {
-            from_peer_id: Arc::new("peer1".to_string()),
-            to_peer_id: Some("peer2".to_string()),
+            from_peer_id: PeerID::from_str("peer1").unwrap(),
+            to_peer_id: Some(PeerID::from_str("peer2").unwrap()),
             data: Arc::from(data2),
         };
 
@@ -101,8 +104,8 @@ mod tests {
 
         let data3 = serde_json::value::to_raw_value(r#"{"message":"different"}"#).unwrap();
         let forward3 = PeerRequest::Forward {
-            from_peer_id: Arc::new("peer1".to_string()),
-            to_peer_id: Some("peer2".to_string()),
+            from_peer_id: PeerID::from_str("peer1").unwrap(),
+            to_peer_id: Some(PeerID::from_str("peer2").unwrap()),
             data: Arc::from(data3),
         };
 
@@ -110,19 +113,19 @@ mod tests {
 
         assert_ne!(PeerRequest::KeepAlive, forward1);
 
-        let from_id1 = Arc::new("peer1".to_string());
-        let from_id2 = Arc::new("peer2".to_string());
+        let from_id1 = PeerID::from_str("peer1").unwrap();
+        let from_id2 = PeerID::from_str("peer2").unwrap();
         let data_same = serde_json::value::to_raw_value(r#"{"message":"hello"}"#).unwrap();
 
         let forward_a = PeerRequest::Forward {
-            from_peer_id: from_id1.clone(),
-            to_peer_id: Some("target".to_string()),
+            from_peer_id: from_id1,
+            to_peer_id: Some(PeerID::from_str("target").unwrap()),
             data: Arc::from(data_same.clone()),
         };
 
         let forward_b = PeerRequest::Forward {
             from_peer_id: from_id2,
-            to_peer_id: Some("target".to_string()),
+            to_peer_id: Some(PeerID::from_str("target").unwrap()),
             data: Arc::from(data_same),
         };
 
@@ -132,7 +135,7 @@ mod tests {
     #[test]
     fn test_peer_event_serialization() {
         let new_peer = PeerEvent::NewPeer {
-            peer_id: "peer1".to_string(),
+            peer_id: PeerID::from_str("peer1").unwrap(),
         };
 
         let serialized = serde_json::to_string(&new_peer).unwrap();

--- a/sf-protocol/src/lib.rs
+++ b/sf-protocol/src/lib.rs
@@ -69,10 +69,12 @@ mod tests {
 
     #[test]
     fn test_peer_request_forward_serialization() {
+        let from_peer_id = PeerID::from_str("01").unwrap();
+        println!("{from_peer_id}");
         let data = serde_json::value::to_raw_value(r#"{"message":"hello"}"#).unwrap();
         let forward = PeerRequest::Forward {
-            from_peer_id: PeerID::from_str("peer1").unwrap(),
-            to_peer_id: Some(PeerID::from_str("peer2").unwrap()),
+            from_peer_id: PeerID::from_str("01").unwrap(),
+            to_peer_id: Some(PeerID::from_str("02").unwrap()),
             data: Arc::from(data),
         };
 
@@ -89,14 +91,14 @@ mod tests {
         let data2 = serde_json::value::to_raw_value(r#"{"message":"hello"}"#).unwrap();
 
         let forward1 = PeerRequest::Forward {
-            from_peer_id: PeerID::from_str("peer1").unwrap(),
-            to_peer_id: Some(PeerID::from_str("peer2").unwrap()),
+            from_peer_id: PeerID::from_str("01").unwrap(),
+            to_peer_id: Some(PeerID::from_str("02").unwrap()),
             data: Arc::from(data1),
         };
 
         let forward2 = PeerRequest::Forward {
-            from_peer_id: PeerID::from_str("peer1").unwrap(),
-            to_peer_id: Some(PeerID::from_str("peer2").unwrap()),
+            from_peer_id: PeerID::from_str("01").unwrap(),
+            to_peer_id: Some(PeerID::from_str("02").unwrap()),
             data: Arc::from(data2),
         };
 
@@ -104,8 +106,8 @@ mod tests {
 
         let data3 = serde_json::value::to_raw_value(r#"{"message":"different"}"#).unwrap();
         let forward3 = PeerRequest::Forward {
-            from_peer_id: PeerID::from_str("peer1").unwrap(),
-            to_peer_id: Some(PeerID::from_str("peer2").unwrap()),
+            from_peer_id: PeerID::from_str("01").unwrap(),
+            to_peer_id: Some(PeerID::from_str("02").unwrap()),
             data: Arc::from(data3),
         };
 
@@ -113,19 +115,19 @@ mod tests {
 
         assert_ne!(PeerRequest::KeepAlive, forward1);
 
-        let from_id1 = PeerID::from_str("peer1").unwrap();
-        let from_id2 = PeerID::from_str("peer2").unwrap();
+        let from_id1 = PeerID::from_str("01").unwrap();
+        let from_id2 = PeerID::from_str("02").unwrap();
         let data_same = serde_json::value::to_raw_value(r#"{"message":"hello"}"#).unwrap();
 
         let forward_a = PeerRequest::Forward {
             from_peer_id: from_id1,
-            to_peer_id: Some(PeerID::from_str("target").unwrap()),
+            to_peer_id: Some(PeerID::from_str("02").unwrap()),
             data: Arc::from(data_same.clone()),
         };
 
         let forward_b = PeerRequest::Forward {
             from_peer_id: from_id2,
-            to_peer_id: Some(PeerID::from_str("target").unwrap()),
+            to_peer_id: Some(PeerID::from_str("02").unwrap()),
             data: Arc::from(data_same),
         };
 
@@ -135,11 +137,11 @@ mod tests {
     #[test]
     fn test_peer_event_serialization() {
         let new_peer = PeerEvent::NewPeer {
-            peer_id: PeerID::from_str("peer1").unwrap(),
+            peer_id: PeerID::from_str("01").unwrap(),
         };
 
         let serialized = serde_json::to_string(&new_peer).unwrap();
-        assert_eq!(serialized, r#"{"new_peer":{"peer_id":"peer1"}}"#);
+        assert_eq!(serialized, r#"{"new_peer":{"peer_id":[1,1]}}"#);
 
         let deserialized: PeerEvent = serde_json::from_str(&serialized).unwrap();
 

--- a/sf-server/Cargo.toml
+++ b/sf-server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 sf-metrics = { path = "../sf-metrics" }
 sf-logging = { path = "../sf-logging" }
 sf-protocol = { path = "../sf-protocol" }
+sf-peer-id = { path = "../sf-peer-id" }
 axum = { version = "0.8.3", features = ["ws", "macros"] }
 tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.41"

--- a/sf-server/src/error.rs
+++ b/sf-server/src/error.rs
@@ -21,6 +21,12 @@ pub enum Error {
     /// not be delivered.
     #[error("Send error: peer receiver has been dropped")]
     SendChannelClosed,
+
+    #[error("serde error: {0}")]
+    Serde(serde_json::Error),
+
+    #[error("peer id error: {0}")]
+    PeerID(sf_peer_id::Error),
 }
 
 impl<T> From<tokio::sync::mpsc::error::SendError<T>> for Error {

--- a/sf-server/src/error.rs
+++ b/sf-server/src/error.rs
@@ -1,3 +1,5 @@
+use sf_peer_id::PeerID;
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("bind: {0}")]
@@ -9,11 +11,11 @@ pub enum Error {
 
     /// Error on get peer not found
     #[error("Peer not found: {0}")]
-    PeerNotFound(String),
+    PeerNotFound(PeerID),
 
     /// Error when trying to add a peer that already exists
     #[error("Peer already exists: {0}")]
-    PeerAlreadyExists(String),
+    PeerAlreadyExists(PeerID),
 
     /// The peer‑specific mpsc channel is closed, so the message could
     /// not be delivered.

--- a/sf-server/src/extract_peer_id.rs
+++ b/sf-server/src/extract_peer_id.rs
@@ -199,7 +199,7 @@ mod tests {
 
         let request = Request::builder()
             .uri("/test")
-            .header(PEER_ID_HEADER, "test-peer-id")
+            .header(PEER_ID_HEADER, "01")
             .body(Body::empty())
             .unwrap();
 
@@ -208,7 +208,7 @@ mod tests {
 
         let body = response.into_body();
         let bytes = body.collect().await.unwrap().to_bytes();
-        assert_eq!(&bytes[..], b"test-peer-id");
+        assert_eq!(&bytes[..], b"01");
 
         // assert!(logs_contain("Extracting peer ID from"))
     }
@@ -236,7 +236,7 @@ mod tests {
         let app = setup();
 
         let request = Request::builder()
-            .uri("/test?peer_id=test-peer-id")
+            .uri("/test?peer_id=01")
             .body(Body::empty())
             .unwrap();
 
@@ -245,7 +245,7 @@ mod tests {
 
         let body = response.into_body();
         let bytes = body.collect().await.unwrap().to_bytes();
-        assert_eq!(&bytes[..], b"test-peer-id");
+        assert_eq!(&bytes[..], b"01");
     }
 
     #[tokio::test]

--- a/sf-server/src/main.rs
+++ b/sf-server/src/main.rs
@@ -70,7 +70,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let mut connected = false;
-        let websocket_url = format!("ws://{server_addr}/ws?peer_id=test_main");
+        let websocket_url = format!("ws://{server_addr}/ws?peer_id=01");
 
         for i in 0..5 {
             tokio::time::sleep(Duration::from_millis(100 * (i + 1))).await;

--- a/sf-server/src/main.rs
+++ b/sf-server/src/main.rs
@@ -6,7 +6,6 @@ mod builder;
 mod error;
 mod extract_peer_id;
 mod peer_handler;
-mod peer_id;
 mod server;
 mod socket_metadata;
 mod state;

--- a/sf-server/src/peer_handler.rs
+++ b/sf-server/src/peer_handler.rs
@@ -159,7 +159,7 @@ mod tests {
 
     fn setup() -> (PeerHandler, InMemoryMetrics, Receiver<Arc<PeerRequest>>) {
         let localhost = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-        let meta = SocketMetadata::new(localhost, PeerID::from_str("test_peer").unwrap());
+        let meta = SocketMetadata::new(localhost, PeerID::from_str("01").unwrap());
         let (sender, receiver) = mpsc::channel::<Arc<PeerRequest>>(1);
         let metrics = InMemoryMetrics::new();
         let peer_handler = PeerHandler::new(meta.clone(), sender, &metrics);
@@ -169,7 +169,7 @@ mod tests {
     #[test]
     fn test_peer_handler_new() {
         let (_peer_handler, metrics, _receiver) = setup();
-        let labels = &[("peer_id", "test_peer")];
+        let labels = &[("peer_id", "01")];
 
         // Check if counters exist and have the correct initial value
         assert_eq!(
@@ -192,14 +192,14 @@ mod tests {
     #[test]
     fn test_peer_id() {
         let (peer_handler, _metrics, _receiver) = setup();
-        assert_eq!(peer_handler.id(), &PeerID::from_str("test_peer").unwrap());
+        assert_eq!(peer_handler.id(), &PeerID::from_str("01").unwrap());
     }
 
     #[test]
     fn test_meta() {
         let (peer_handler, _metrics, _receiver) = setup();
         let meta = peer_handler.meta();
-        assert_eq!(meta.peer_id, PeerID::from_str("test_peer").unwrap());
+        assert_eq!(meta.peer_id, PeerID::from_str("01").unwrap());
         assert_eq!(
             meta.origin,
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080)
@@ -209,7 +209,7 @@ mod tests {
     #[tokio::test]
     async fn test_send_increments_metric_and_sends() {
         let (peer_handler, metrics, mut receiver) = setup();
-        let labels = &[("peer_id", "test_peer")];
+        let labels = &[("peer_id", "01")];
 
         let message = Arc::new(PeerRequest::KeepAlive);
         let result = peer_handler.send(Arc::clone(&message)).await;
@@ -230,7 +230,7 @@ mod tests {
     #[tokio::test]
     async fn test_send_fails_when_receiver_dropped() {
         let (peer_handler, metrics, receiver) = setup();
-        let labels = &[("peer_id", "test_peer")];
+        let labels = &[("peer_id", "01")];
 
         // Drop the receiver to simulate the channel being closed
         drop(receiver);
@@ -259,7 +259,7 @@ mod tests {
 
         // Check that the output contains the key fields
         assert!(debug_output.contains("PeerHandler"));
-        assert!(debug_output.contains("peer_id: \"test_peer\""));
+        assert!(debug_output.contains("PeerID<32>(01)"));
         assert!(debug_output.contains("origin: 127.0.0.1:8080"));
     }
 
@@ -267,7 +267,7 @@ mod tests {
     async fn test_process_incoming() {
         // Setup
         let (peer_handler, metrics, _receiver) = setup();
-        let labels = &[("peer_id", "test_peer")];
+        let labels = &[("peer_id", "01")];
 
         // Create a direct mock of AppState with the exact methods that PeerHandler.process_incoming
         // calls
@@ -324,8 +324,8 @@ mod tests {
 
         let forward_msg = axum::extract::ws::Message::Text(
             serde_json::to_string(&PeerRequest::Forward {
-                from_peer_id: PeerID::from_str("sender").unwrap(),
-                to_peer_id: Some(PeerID::from_str("recipient").unwrap()),
+                from_peer_id: PeerID::from_str("01").unwrap(),
+                to_peer_id: Some(PeerID::from_str("02").unwrap()),
                 data: Arc::from(serde_json::value::to_raw_value("hello").unwrap()),
             })
             .unwrap()

--- a/sf-server/src/peer_id.rs
+++ b/sf-server/src/peer_id.rs
@@ -1,3 +1,0 @@
-use std::sync::Arc;
-
-pub type PeerID = Arc<String>;

--- a/sf-server/src/socket_metadata.rs
+++ b/sf-server/src/socket_metadata.rs
@@ -1,6 +1,5 @@
+use sf_peer_id::PeerID;
 use std::{fmt, net::SocketAddr};
-
-use crate::peer_id::PeerID;
 
 #[derive(Clone)]
 pub struct SocketMetadata {
@@ -26,13 +25,15 @@ impl fmt::Debug for SocketMetadata {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
 
     #[test]
     fn test_new() {
         let origin = SocketAddr::from(([127, 0, 0, 1], 8080));
-        let peer_id = PeerID::new("test_peer_id".to_string());
-        let metadata = SocketMetadata::new(origin, peer_id.clone());
+        let peer_id = PeerID::from_str("test_peer_id").unwrap();
+        let metadata = SocketMetadata::new(origin, peer_id);
 
         assert_eq!(metadata.origin, origin);
         assert_eq!(metadata.peer_id, peer_id);
@@ -41,8 +42,8 @@ mod tests {
     #[test]
     fn test_debug() {
         let origin = SocketAddr::from(([127, 0, 0, 1], 8080));
-        let peer_id = PeerID::new("test_peer_id".to_string());
-        let metadata = SocketMetadata::new(origin, peer_id.clone());
+        let peer_id = PeerID::from_str("test_peer_id").unwrap();
+        let metadata = SocketMetadata::new(origin, peer_id);
 
         assert_eq!(
             format!("{metadata:?}"),

--- a/sf-server/src/socket_metadata.rs
+++ b/sf-server/src/socket_metadata.rs
@@ -32,7 +32,7 @@ mod tests {
     #[test]
     fn test_new() {
         let origin = SocketAddr::from(([127, 0, 0, 1], 8080));
-        let peer_id = PeerID::from_str("test_peer_id").unwrap();
+        let peer_id = PeerID::from_str("01").unwrap();
         let metadata = SocketMetadata::new(origin, peer_id);
 
         assert_eq!(metadata.origin, origin);
@@ -42,7 +42,7 @@ mod tests {
     #[test]
     fn test_debug() {
         let origin = SocketAddr::from(([127, 0, 0, 1], 8080));
-        let peer_id = PeerID::from_str("test_peer_id").unwrap();
+        let peer_id = PeerID::from_str("01").unwrap();
         let metadata = SocketMetadata::new(origin, peer_id);
 
         assert_eq!(

--- a/sf-server/src/state.rs
+++ b/sf-server/src/state.rs
@@ -2,10 +2,11 @@ use dashmap::DashMap;
 use serde_json::value::RawValue;
 use sf_logging::{debug, error, info, warn};
 use sf_metrics::{Counter, Gauge, Metrics};
+use sf_peer_id::PeerID;
 use sf_protocol::{PeerEvent, PeerRequest};
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
-use crate::{peer_handler::PeerHandler, peer_id::PeerID};
+use crate::peer_handler::PeerHandler;
 
 const SYSTEM_EVENT_PREFIX: &str = "system";
 
@@ -14,7 +15,7 @@ pub(crate) struct AppState<M>
 where
     M: Metrics + Clone + Send + Sync + 'static,
 {
-    pub(crate) peers: DashMap<String, PeerHandler>,
+    pub(crate) peers: DashMap<PeerID, PeerHandler>,
 
     metrics: M,
 
@@ -41,24 +42,21 @@ impl<M: Metrics> AppState<M> {
     }
 
     pub(crate) async fn add_peer(&self, peer_handler: PeerHandler) -> Result<PeerID, crate::Error> {
-        let peer_id = peer_handler.id().clone();
-        let key = peer_id.to_string();
+        let peer_id = peer_handler.id();
 
-        if self.peers.contains_key(&key) {
-            warn!("Attempted to add existing peer: {key}");
-            return Err(crate::Error::PeerAlreadyExists(key));
+        if self.peers.contains_key(peer_id) {
+            warn!("Attempted to add existing peer: {peer_id}");
+            return Err(crate::Error::PeerAlreadyExists(*peer_id));
         }
 
-        self.peers.insert(key.clone(), peer_handler);
+        self.peers.insert(*peer_id, peer_handler.clone());
         self.peer_count.increment();
-        debug!("Peer added: {key}");
+        debug!("Peer added: {peer_id}");
 
-        self.broadcast_system_event_and_log(PeerEvent::NewPeer {
-            peer_id: key.clone(),
-        })
-        .await;
+        self.broadcast_system_event_and_log(PeerEvent::NewPeer { peer_id: *peer_id })
+            .await;
 
-        Ok(peer_id)
+        Ok(*peer_id)
     }
 
     #[inline]
@@ -69,17 +67,17 @@ impl<M: Metrics> AppState<M> {
         }
     }
 
-    pub(crate) fn remove_peer(&self, peer_id: &str) {
+    pub(crate) fn remove_peer(&self, peer_id: &PeerID) {
         if self.peers.remove(peer_id).is_some() {
             self.peer_count.decrement();
             debug!("Peer removed: {peer_id}");
         }
     }
 
-    pub(crate) async fn send_to_peer(&self, peer_id: &str, payload: Arc<PeerRequest>) {
+    pub(crate) async fn send_to_peer(&self, peer_id: &PeerID, payload: Arc<PeerRequest>) {
         if let Some(entry) = self.peers.get(peer_id) {
             let handler = entry.value().clone();
-            let _peer_id_arc = entry.key().clone();
+            let _peer_id_arc = *entry.key();
 
             tokio::spawn(async move {
                 if handler.send(payload).await.is_err() {
@@ -99,7 +97,7 @@ impl<M: Metrics> AppState<M> {
         &self,
         from_peer_id: PeerID,
         connection_peer_id: PeerID,
-        to_peer_id: Option<String>,
+        to_peer_id: Option<PeerID>,
         data: Arc<RawValue>,
     ) {
         match to_peer_id {
@@ -111,10 +109,10 @@ impl<M: Metrics> AppState<M> {
         }
     }
 
-    async fn forward_single(&self, from_peer: PeerID, to_peer: String, data: Arc<RawValue>) {
+    async fn forward_single(&self, from_peer: PeerID, to_peer: PeerID, data: Arc<RawValue>) {
         self.send_forward(&from_peer, &to_peer, data).await;
         self.message_forwarded
-            .with_labels(&[("peer_id", &to_peer)])
+            .with_labels(&[("peer_id", &to_peer.to_string())])
             .increment();
     }
 
@@ -122,15 +120,15 @@ impl<M: Metrics> AppState<M> {
         &self,
         from_peer_id: PeerID,
         data: Arc<RawValue>,
-        exclude: Option<&str>,
+        exclude: Option<&PeerID>,
     ) {
         info!(
             "Broadcasting from {from_peer_id} to {} peers (exclude: {exclude:?})",
             self.peers.len().saturating_sub(exclude.map_or(0, |_| 1))
         );
-        let ids: Vec<String> = self.peers.iter().map(|e| e.key().clone()).collect();
+        let ids: Vec<PeerID> = self.peers.iter().map(|e| *e.key()).collect();
         for pid in ids {
-            if exclude.is_some_and(|ex| ex == pid) {
+            if exclude.is_some_and(|ex| ex == &pid) {
                 continue;
             }
             self.send_forward(&from_peer_id, &pid, data.clone()).await;
@@ -138,18 +136,19 @@ impl<M: Metrics> AppState<M> {
         self.message_broadcast.increment();
     }
 
-    async fn send_forward(&self, from: &PeerID, to: &str, data: Arc<RawValue>) {
+    async fn send_forward(&self, from: &PeerID, to: &PeerID, data: Arc<RawValue>) {
         let req = Arc::new(PeerRequest::Forward {
-            from_peer_id: Arc::clone(from),
-            to_peer_id: Some(to.to_owned()),
+            from_peer_id: *from,
+            to_peer_id: Some(*to),
             data,
         });
         self.send_to_peer(to, req).await;
     }
 
     async fn broadcast_system_event(&self, event: PeerEvent) -> Result<(), serde_json::Error> {
+        let system_event_peer_id = PeerID::from_str(SYSTEM_EVENT_PREFIX).unwrap();
         let raw = Arc::from(RawValue::from_string(serde_json::to_string(&event)?)?);
-        self.broadcast_forward_except(Arc::new(SYSTEM_EVENT_PREFIX.into()), raw, None)
+        self.broadcast_forward_except(system_event_peer_id, raw, None)
             .await;
         Ok(())
     }
@@ -165,7 +164,7 @@ pub trait AppStateInterface: Send + Sync + 'static {
         &self,
         from_peer_id: PeerID,
         connection_peer_id: PeerID,
-        to_peer_id: Option<String>,
+        to_peer_id: Option<PeerID>,
         data: Arc<RawValue>,
     );
 }
@@ -182,7 +181,7 @@ where
         &self,
         from_peer_id: PeerID,
         connection_peer_id: PeerID,
-        to_peer_id: Option<String>,
+        to_peer_id: Option<PeerID>,
         data: Arc<RawValue>,
     ) {
         self.handle_forward(from_peer_id, connection_peer_id, to_peer_id, data)
@@ -215,7 +214,7 @@ mod tests {
         let (tx, _) = mpsc::channel::<Arc<PeerRequest>>(100);
 
         let origin = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-        let peer_id = PeerID::new("peer_id".to_string());
+        let peer_id = PeerID::from_str("peer_id").unwrap();
         let peer_handler =
             PeerHandler::new(SocketMetadata::new(origin, peer_id), tx, state.metrics());
 
@@ -230,7 +229,7 @@ mod tests {
         let (tx, _) = mpsc::channel::<Arc<PeerRequest>>(100);
 
         let origin = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-        let peer_id = PeerID::new("peer_id".to_string());
+        let peer_id = PeerID::from_str("peer_id").unwrap();
         let peer_handler =
             PeerHandler::new(SocketMetadata::new(origin, peer_id), tx, state.metrics());
 
@@ -250,12 +249,9 @@ mod tests {
 
         let (tx, _) = mpsc::channel::<Arc<PeerRequest>>(100);
         let origin = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-        let peer_id = PeerID::new("peer_id".to_string());
-        let peer_handler = PeerHandler::new(
-            SocketMetadata::new(origin, peer_id.clone()),
-            tx,
-            state.metrics(),
-        );
+        let peer_id = PeerID::from_str("peer_id").unwrap();
+        let peer_handler =
+            PeerHandler::new(SocketMetadata::new(origin, peer_id), tx, state.metrics());
 
         let peer_id_arc = state.add_peer(peer_handler.clone()).await.unwrap();
         assert_eq!(peer_id_arc.to_string(), "peer_id");
@@ -267,11 +263,11 @@ mod tests {
     #[tokio::test]
     async fn send_to_unknow_peer() {
         let state = get_app_state();
-        let peer_id = PeerID::new("peer_id".to_string());
+        let peer_id = PeerID::from_str("peer_id").unwrap();
         let data: Arc<RawValue> = Arc::from(RawValue::from_string("{}".to_string()).unwrap());
         state
             .send_to_peer(
-                &peer_id.clone(),
+                &peer_id,
                 Arc::new(PeerRequest::Forward {
                     from_peer_id: peer_id,
                     to_peer_id: None,
@@ -289,18 +285,15 @@ mod tests {
         let (tx, _) = mpsc::channel::<Arc<PeerRequest>>(100);
 
         let origin = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-        let peer_id = PeerID::new("peer_id".to_string());
-        let peer_handler = PeerHandler::new(
-            SocketMetadata::new(origin, peer_id.clone()),
-            tx,
-            state.metrics(),
-        );
+        let peer_id = PeerID::from_str("peer_id").unwrap();
+        let peer_handler =
+            PeerHandler::new(SocketMetadata::new(origin, peer_id), tx, state.metrics());
 
         let peer_id_after_add_peer = state.add_peer(peer_handler).await.unwrap();
         assert_eq!(peer_id_after_add_peer.to_string(), "peer_id");
 
         let (tx_2, mut rx_2) = mpsc::channel::<Arc<PeerRequest>>(100);
-        let peer_id_2 = PeerID::new("peer_id_2".to_string());
+        let peer_id_2 = PeerID::from_str("peer_id_2").unwrap();
         let meta_2 = SocketMetadata::new(origin, peer_id_2);
         let peer_handler_2 = PeerHandler::new(meta_2, tx_2, state.metrics());
 
@@ -310,7 +303,7 @@ mod tests {
         let data: Arc<RawValue> =
             Arc::from(RawValue::from_string(r#"{"message":"hello"}"#.to_string()).unwrap());
         state
-            .broadcast_forward_except(peer_id_after_add_peer, data, Some(&peer_id.clone()))
+            .broadcast_forward_except(peer_id_after_add_peer, data, Some(&peer_id))
             .await;
 
         let received_message = rx_2.recv().await.unwrap();
@@ -322,7 +315,7 @@ mod tests {
                 data,
             } => {
                 assert_eq!(from_peer_id.to_string(), "system");
-                assert_eq!(to_peer_id, &Some("peer_id_2".to_string()));
+                assert_eq!(to_peer_id, &Some(peer_id_2));
                 assert_eq!(
                     data.get().to_string(),
                     r#"{"new_peer":{"peer_id":"peer_id_2"}}"#
@@ -340,7 +333,7 @@ mod tests {
                 data,
             } => {
                 assert_eq!(from_peer_id.to_string(), "peer_id_2");
-                assert_eq!(to_peer_id, &Some("peer_id_2".to_string()));
+                assert_eq!(to_peer_id, &Some(peer_id_2));
                 assert_eq!(data.get().to_string(), r#"{"message":"hello"}"#);
             }
             _ => panic!("Expected Forward message, got: {received_message:?}"),
@@ -354,8 +347,8 @@ mod tests {
         let origin = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
 
         let (tx1, _rx1) = mpsc::channel::<Arc<PeerRequest>>(100);
-        let peer_id1 = PeerID::new("peer1_interface_test".to_string());
-        let meta1 = SocketMetadata::new(origin, peer_id1.clone());
+        let peer_id1 = PeerID::from_str("peer1_interface_test").unwrap();
+        let meta1 = SocketMetadata::new(origin, peer_id1);
         let handler1 = PeerHandler::new(meta1, tx1, state.metrics());
         state
             .add_peer(handler1)
@@ -363,8 +356,8 @@ mod tests {
             .expect("Failed to add peer 1");
 
         let (tx2, mut rx2) = mpsc::channel::<Arc<PeerRequest>>(100);
-        let peer_id2 = PeerID::new("peer2_interface_test".to_string());
-        let meta2 = SocketMetadata::new(origin, peer_id2.clone());
+        let peer_id2 = PeerID::from_str("peer2_interface_test").unwrap();
+        let meta2 = SocketMetadata::new(origin, peer_id2);
         let handler2 = PeerHandler::new(meta2, tx2, state.metrics());
         state
             .add_peer(handler2)
@@ -372,8 +365,8 @@ mod tests {
             .expect("Failed to add peer 2");
 
         let (tx3, mut rx3) = mpsc::channel::<Arc<PeerRequest>>(100);
-        let peer_id3 = PeerID::new("peer3_interface_test".to_string());
-        let meta3 = SocketMetadata::new(origin, peer_id3.clone());
+        let peer_id3 = PeerID::from_str("peer3_interface_test").unwrap();
+        let meta3 = SocketMetadata::new(origin, peer_id3);
         let handler3 = PeerHandler::new(meta3, tx3, state.metrics());
         state
             .add_peer(handler3)
@@ -385,19 +378,18 @@ mod tests {
         while rx3.try_recv().is_ok() {}
 
         debug!("Calling handle_keepalive via trait");
-        AppStateInterface::handle_keepalive(state.as_ref(), peer_id1.clone()).await;
+        AppStateInterface::handle_keepalive(state.as_ref(), peer_id1).await;
         debug!("Finished handle_keepalive via trait");
 
         let data: Arc<RawValue> =
             Arc::from(RawValue::from_string(r#"{"msg": "direct"}"#.to_string()).unwrap());
-        let target_peer = Some(peer_id2.to_string());
 
         debug!("Calling handle_forward (direct) via trait");
         AppStateInterface::handle_forward(
             state.as_ref(),
-            peer_id1.clone(),
-            peer_id1.clone(),
-            target_peer.clone(),
+            peer_id1,
+            peer_id1,
+            Some(peer_id2),
             data.clone(),
         )
         .await;
@@ -411,7 +403,7 @@ mod tests {
                 data: received_data,
             } => {
                 assert_eq!(from_peer_id, &peer_id1, "Originating peer ID mismatch");
-                assert_eq!(to_peer_id, &target_peer, "Target peer ID mismatch");
+                assert_eq!(to_peer_id, &Some(peer_id2), "Target peer ID mismatch");
                 assert_eq!(received_data.get(), r#"{"msg": "direct"}"#, "Data mismatch");
             }
             _ => panic!("Expected Forward request, got {received:?}"),
@@ -427,8 +419,8 @@ mod tests {
         debug!("Calling handle_forward (broadcast) via trait");
         AppStateInterface::handle_forward(
             state.as_ref(),
-            peer_id1.clone(),
-            peer_id1.clone(),
+            peer_id1,
+            peer_id1,
             None,
             broadcast_data.clone(),
         )
@@ -444,8 +436,8 @@ mod tests {
             } => {
                 assert_eq!(from_peer_id, &peer_id1);
                 assert_eq!(
-                    to_peer_id.as_ref().map(|s| s.as_str()),
-                    Some(peer_id2.as_str())
+                    to_peer_id.as_ref().map(|s| s.to_string()),
+                    Some(peer_id2.to_string())
                 );
                 assert_eq!(received_data.get(), r#"{"msg": "broadcast"}"#);
             }
@@ -461,8 +453,8 @@ mod tests {
             } => {
                 assert_eq!(from_peer_id, &peer_id1);
                 assert_eq!(
-                    to_peer_id.as_ref().map(|s| s.as_str()),
-                    Some(peer_id3.as_str())
+                    to_peer_id.as_ref().map(|s| s.to_string()),
+                    Some(peer_id3.to_string())
                 ); // Check target
                 assert_eq!(received_data.get(), r#"{"msg": "broadcast"}"#);
             }

--- a/sf-server/src/ws.rs
+++ b/sf-server/src/ws.rs
@@ -115,8 +115,6 @@ async fn process_ws<M, W, R>(
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use crate::peer_id::PeerID;
-
     use super::*;
     use std::{
         net::{Ipv4Addr, SocketAddr},
@@ -127,6 +125,7 @@ mod tests {
 
     use axum::{Router, extract::connect_info::IntoMakeServiceWithConnectInfo, routing::get};
     use sf_metrics::InMemoryMetrics;
+    use sf_peer_id::PeerID;
     use sf_protocol::PeerRequest;
     use tracing_test::traced_test;
 
@@ -143,7 +142,7 @@ mod tests {
     }
 
     async fn setup_ws_connection(
-        test_peer_id: &str,
+        test_peer_id: &PeerID,
     ) -> (
         tokio::task::JoinHandle<Result<(), std::io::Error>>,
         tokio_tungstenite::WebSocketStream<
@@ -181,7 +180,7 @@ mod tests {
     #[tokio::test]
     async fn test_ws_upgrade() {
         let (server_task, ws_stream, _addr, _state) =
-            setup_ws_connection("test_peer_upgrade").await;
+            setup_ws_connection(&PeerID::from_str("test_peer_upgrade").unwrap()).await;
 
         drop(ws_stream);
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -191,11 +190,11 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_process_ws_outbound_send_error() {
-        let test_peer_id = "peer_send_error";
-        let (server_task, mut ws_stream, _addr, state) = setup_ws_connection(test_peer_id).await;
+        let test_peer_id = PeerID::from_str("peer_send_error").unwrap();
+        let (server_task, mut ws_stream, _addr, state) = setup_ws_connection(&test_peer_id).await;
 
         assert!(
-            state.peers.contains_key(test_peer_id),
+            state.peers.contains_key(&test_peer_id),
             "Peer should be in state after connection"
         );
 
@@ -206,12 +205,12 @@ mod tests {
 
         let dummy_request = Arc::new(PeerRequest::KeepAlive);
         println!("sending");
-        state.send_to_peer(test_peer_id, dummy_request).await;
+        state.send_to_peer(&test_peer_id, dummy_request).await;
 
         tokio::time::sleep(Duration::from_millis(200)).await;
 
         assert!(
-            !state.peers.contains_key(test_peer_id),
+            !state.peers.contains_key(&test_peer_id),
             "Peer should be removed after send error"
         );
 
@@ -225,7 +224,7 @@ mod tests {
         let (tx, rx) = mpsc::channel::<Arc<PeerRequest>>(32);
         let meta = SocketMetadata::new(
             SocketAddr::from_str("127.0.0.1:12312").unwrap(),
-            PeerID::new("toto".to_string()),
+            PeerID::from_str("toto").unwrap(),
         );
         let handler = PeerHandler::new(meta, tx, state.metrics());
 

--- a/sf-server/src/ws.rs
+++ b/sf-server/src/ws.rs
@@ -180,7 +180,7 @@ mod tests {
     #[tokio::test]
     async fn test_ws_upgrade() {
         let (server_task, ws_stream, _addr, _state) =
-            setup_ws_connection(&PeerID::from_str("test_peer_upgrade").unwrap()).await;
+            setup_ws_connection(&PeerID::from_str("01").unwrap()).await;
 
         drop(ws_stream);
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -190,8 +190,12 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_process_ws_outbound_send_error() {
-        let test_peer_id = PeerID::from_str("peer_send_error").unwrap();
+        let test_peer_id = PeerID::from_str("01").unwrap();
         let (server_task, mut ws_stream, _addr, state) = setup_ws_connection(&test_peer_id).await;
+
+        for k in state.peers.iter().map(|e| *e.key()) {
+            println!("In map: {} (size = {})", k, k.size());
+        }
 
         assert!(
             state.peers.contains_key(&test_peer_id),
@@ -204,7 +208,6 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let dummy_request = Arc::new(PeerRequest::KeepAlive);
-        println!("sending");
         state.send_to_peer(&test_peer_id, dummy_request).await;
 
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -224,7 +227,7 @@ mod tests {
         let (tx, rx) = mpsc::channel::<Arc<PeerRequest>>(32);
         let meta = SocketMetadata::new(
             SocketAddr::from_str("127.0.0.1:12312").unwrap(),
-            PeerID::from_str("toto").unwrap(),
+            PeerID::from_str("01").unwrap(),
         );
         let handler = PeerHandler::new(meta, tx, state.metrics());
 
@@ -246,7 +249,7 @@ mod tests {
 
         #[cfg(not(coverage))]
         assert!(
-            logs_contain("Failed to send message to toto: SendError { "),
+            logs_contain("Failed to send message to 01: SendError { "),
             "log not found"
         );
     }
@@ -261,7 +264,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let server_task = tokio::spawn(axum::serve(listener, app).into_future());
 
-        let connect_url = format!("ws://{addr}/ws?peer_id=toto");
+        let connect_url = format!("ws://{addr}/ws?peer_id=01");
 
         let mut attempt = 0;
         let (ws_stream, _) = loop {
@@ -292,7 +295,7 @@ mod tests {
 
         #[cfg(not(coverage))]
         assert!(
-            logs_contain("Failed to register peer toto: Peer already exists: toto"),
+            logs_contain("Failed to register peer 01: Peer already exists: 01"),
             "log not found"
         );
 


### PR DESCRIPTION
Signed-off-by: Sacha Froment <sfroment42@gmail.com>
